### PR TITLE
F Sub Bugs Fix ✅

### DIFF
--- a/database/users_chats_db.py
+++ b/database/users_chats_db.py
@@ -19,11 +19,15 @@ class Database:
         self.codes = self.db.codes
         self.connection = self.db.connections
 
-    async def find_join_req(self, id):
-        return bool(await self.req.find_one({'id': id})) 
-     
-    async def add_join_req(self, id):
-        await self.req.insert_one({'id': id})
+    async def add_join_req(self, user_id, channel_id):
+        await self.req.update_one(
+            {"id": user_id, "channel_id": channel_id},
+            {"$set": {"id": user_id, "channel_id": channel_id}},
+            upsert=True
+        )
+        
+    async def find_join_req(self, user_id, channel_id):
+        return bool(await self.req.find_one({'id': user_id, 'channel_id': channel_id}))
 
     async def del_join_req(self):
         await self.req.drop()

--- a/plugins/commands.py
+++ b/plugins/commands.py
@@ -30,7 +30,10 @@ BATCH_FILES = {}
 @Client.on_message(filters.command("start") & filters.incoming)
 async def start(client, message):
     if EMOJI_MODE:
-        await message.react(emoji=random.choice(REACTIONS))
+        try:
+            await message.react(emoji=random.choice(REACTIONS))
+        except Exception as e:
+            print(f"Failed to react: {e}")
     m = message
     if len(m.command) == 2 and m.command[1].startswith(('notcopy', 'sendall')):
         _, userid, verify_id, file_id = m.command[1].split("_", 3)

--- a/plugins/join_req.py
+++ b/plugins/join_req.py
@@ -7,8 +7,8 @@ from info import ADMINS, AUTH_CHANNEL
 
 @Client.on_chat_join_request(filters.chat(AUTH_CHANNEL))
 async def join_reqs(client, message: ChatJoinRequest):
-  if not await db.find_join_req(message.from_user.id):
-    await db.add_join_req(message.from_user.id)
+  if not await db.find_join_req(message.from_user.id, message.chat.id):
+    await db.add_join_req(message.from_user.id, message.chat.id)
 
 @Client.on_message(filters.command("delreq") & filters.private & filters.user(ADMINS))
 async def del_requests(client, message):

--- a/plugins/pm_filter.py
+++ b/plugins/pm_filter.py
@@ -42,7 +42,10 @@ SPELL_CHECK = {}
 @Client.on_message(filters.group & filters.text & filters.incoming)
 async def give_filter(client, message):
     if EMOJI_MODE:
-        await message.react(emoji=random.choice(REACTIONS))
+        try:
+            await message.react(emoji=random.choice(REACTIONS))
+        except Exception as e:
+            print(f"Failed to react: {e}")
     await silentdb.update_top_messages(message.from_user.id, message.text)
     if message.chat.id != SUPPORT_CHAT_ID:
         settings = await get_settings(message.chat.id)
@@ -69,7 +72,10 @@ async def pm_text(bot, message):
     user = message.from_user.first_name
     user_id = message.from_user.id
     if EMOJI_MODE:
-        await message.react(emoji=random.choice(REACTIONS), big=True)
+        try:
+            await message.react(emoji=random.choice(REACTIONS))
+        except Exception as e:
+            print(f"Failed to react: {e}")
     if content.startswith(("/", "#")):
         return  
     try:

--- a/utils.py
+++ b/utils.py
@@ -54,7 +54,7 @@ class temp(object):
     VERIFICATIONS = {}
 
 async def is_req_subscribed(bot, query):
-    if await db.find_join_req(query.from_user.id):
+    if await db.find_join_req(query.from_user.id, AUTH_CHANNEL):
         return True
     try:
         user = await bot.get_chat_member(AUTH_CHANNEL, query.from_user.id)


### PR DESCRIPTION
🔧 Pahle kya hota tha:
Jab bhi force subscribe channel set kiya jata tha, pehli baar user se request to join liya jata tha, aur file de diya jata tha. Lekin agar admin baad mein force subscribe channel ID ko change karta tha, to naye channel ke liye bot dubara request nahi bhejta tha.

Iska reason yeh tha ki pehli baar jo channel tha, uska ID database me save ho jata tha. Aur chahe aap kitni baar channel change kar lo, bot hamesha wahi pehla wala channel check karta tha — agar usme already request diya gaya ho to file de deta tha bina naye channel pe request kiye. Jab tak aap manually /delreq command na do, naye channel ke liye request nahi aata tha. 

Agar /delreq command diya to jo log already Request to join diya tha usko dubara join Request nene ke liye bolta tha

✅ Ab kya hoga (fix ke baad):
Ab aap jitni baar bhi force subscribe channel change karein, bot har baar current auth channel ya group ID ke sath match karega.

Agar user ne naye channel me pehle se request to join diya hai, to bot usse file de dega. Lekin agar naye channel ke liye abhi tak request nahi diya gaya hai, to bot user ko naya request to join dene ke liye force karega.

📌 Isse ab har naye auth channel ke sath sahi tareeke se request to join process chalega, bina purane data ke interference ke.